### PR TITLE
Fix setting options.version

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -34,7 +34,7 @@ class Client {
     this.queryStringToAppend = options.queryStringToAppend || {};
 
     if (this.options.version) {
-      if (!(this.version in supportedVersions)) throw new Error('Version not supported by client');
+      if (!(this.options.version in supportedVersions)) throw new Error('Version not supported by client');
       this.version = this.options.version;
     }
 


### PR DESCRIPTION
The `supportedVersion` check was done against `this.version`, which isn't set yet, instead of `this.options.version`, causing any `version` option to fail the queries.