### PR TITLE
Fix build object

### DIFF
--- a/lib/xml.js
+++ b/lib/xml.js
@@ -35,6 +35,9 @@ exports.mapper = function (definition, ns) {
   }
 
   const buildObject = function (node, type) {
+    if (!node) {
+      return null
+    }
     const result = {}
     forEach(definition[type], (params, xpath) => {
       if (isString(params)) {


### PR DESCRIPTION
Running on `http://www.ifremer.fr/services/wfs/odatis` (v1.0.0), `node.get('Service', ns)` returns null, so `buildObject` is called with `null` and fails.
