### PR TITLE
Cleanup constructor options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,3 @@
-/*
-** Module dependencies
-*/
 const Client = require('./lib/client')
 
-/*
-** Methods
-*/
-function wfs(url, options) {
-  return new Client(url, options)
-}
-
-/*
-** Exports
-*/
-module.exports = wfs
+module.exports = Client

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,7 +5,7 @@ const HttpAgent = require('http').Agent
 const HttpsAgent = require('https').Agent
 const parseUrl = require('url').parse
 const got = require('got')
-const {pick, findLast} = require('lodash')
+const {findLast} = require('lodash')
 const semver = require('semver')
 const debug = require('debug')('wfs')
 const pkg = require('../package.json')
@@ -29,23 +29,34 @@ const supportedVersions = {
 const supportedVersionsKeys = Object.keys(supportedVersions)
 
 class Client {
-  constructor(url, options) {
+  constructor(url, options = {}) {
     if (!url) {
       throw new TypeError('URL is required!')
     }
+
     this.url = url
-    this.options = options || {}
     this.queryStringToAppend = options.queryStringToAppend || {}
 
-    if (this.options.version) {
-      if (!(this.options.version in supportedVersions)) {
+    if (options.version) {
+      if (!(options.version in supportedVersions)) {
         throw new Error('Version not supported by client')
       }
-      this.version = this.options.version
+      this.version = options.version
     }
 
-    if (this.options.maxSockets || this.options.keepAlive) {
-      this.agent = new Agent[parseUrl(url).protocol](pick(this.options, 'keepAlive', 'maxSockets'))
+    this.options = {
+      userAgent: options.userAgent,
+      timeout: options.timeout
+    }
+
+    if (options.maxSockets || options.keepAlive) {
+      const {protocol} = parseUrl(url)
+      const {maxSockets, keepAlive} = options
+
+      this.agent = new Agent[protocol]({
+        maxSockets,
+        keepAlive
+      })
     }
   }
 


### PR DESCRIPTION
Make `new WfsClient(url)` work by specifying a default options object.

Only store real options in `this.options`.